### PR TITLE
feat(INetworkService.cs): create a new interface for network services…

### DIFF
--- a/Orion.Core.Irc.Server/Interfaces/Services/System/INetworkService.cs
+++ b/Orion.Core.Irc.Server/Interfaces/Services/System/INetworkService.cs
@@ -1,7 +1,6 @@
 using Orion.Core.Server.Interfaces.Services.Base;
 
-
-namespace Orion.Core.Server.Interfaces.Services.System;
+namespace Orion.Core.Irc.Server.Interfaces.Services.System;
 
 public interface INetworkService : IOrionService
 {

--- a/src/Orion.Core.Server/Data/Options/OrionServerOptions.cs
+++ b/src/Orion.Core.Server/Data/Options/OrionServerOptions.cs
@@ -8,7 +8,7 @@ namespace Orion.Core.Server.Data.Options;
 public class OrionServerOptions : IOrionServerCmdOptions
 {
     [Option('c', "config", Required = false, HelpText = "Path to the configuration file.")]
-    public string? ConfigFile { get; set; } = null;
+    public string? ConfigFile { get; set; }
 
     [Option('r', "root-directory", Required = false, HelpText = "Root directory for the server.")]
     public string RootDirectory { get; set; } = null!;

--- a/src/Orion.Core.Server/Extensions/ApplicationBuilderExtension.cs
+++ b/src/Orion.Core.Server/Extensions/ApplicationBuilderExtension.cs
@@ -60,9 +60,14 @@ public static class ApplicationBuilderExtension
 
         var directoriesConfig = new DirectoriesConfig(parsedOptions.Value.RootDirectory, defaultDirectories);
 
+        if (parsedOptions.Value.ConfigFile == null)
+        {
+            parsedOptions.Value.ConfigFile = appName.ToSnakeCase() + ".yml";
+        }
+
         serviceCollection.AddSingleton(directoriesConfig);
         appContextData.Config =
-            directoriesConfig.LoadConfig<TConfig>(serviceCollection, parsedOptions.Value.ConfigFile ?? appName.ToSnakeCase() + ".yml");
+            directoriesConfig.LoadConfig<TConfig>(serviceCollection, parsedOptions.Value.ConfigFile);
 
 
         serviceCollection.AddSingleton<IOrionServerConfig>(appContextData.Config);

--- a/src/Orion.Core.Server/Interfaces/Options/IOrionServerCmdOptions.cs
+++ b/src/Orion.Core.Server/Interfaces/Options/IOrionServerCmdOptions.cs
@@ -4,7 +4,7 @@ namespace Orion.Core.Server.Interfaces.Options;
 
 public interface IOrionServerCmdOptions
 {
-    string ConfigFile { get; set; }
+    string? ConfigFile { get; set; }
 
     string RootDirectory { get; set; }
 

--- a/src/Orion.Server/Services/System/NetworkService.cs
+++ b/src/Orion.Server/Services/System/NetworkService.cs
@@ -1,5 +1,6 @@
 using System.Security.Authentication;
 using NetCoreServer;
+using Orion.Core.Irc.Server.Interfaces.Services.System;
 using Orion.Core.Server.Data.Config;
 using Orion.Core.Server.Events.Server;
 using Orion.Core.Server.Extensions;


### PR DESCRIPTION
… to extend IOrionService

refactor(OrionServerOptions.cs): remove unnecessary default assignment for ConfigFile property
refactor(ApplicationBuilderExtension.cs): set default value for ConfigFile if null
refactor(IOrionServerCmdOptions.cs): change ConfigFile property to nullable
feat(NetworkService.cs): import INetworkService interface for network service implementation